### PR TITLE
fix: correct typos, grammar, and critical GuardDuty misdescription

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository will be organized by the main domains of the AWS Cloud Practitio
 - **[Section #6: Amazon S3](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%236%20-%20Amazon%20S3.md)**
 - **[Section #7: Databases](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%237%20-%20Databases%20%26%20Analytics.md)**
 - **[Section #8: ECS, Lambda, API Gateway, Batch & Lightsail](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%238%20-%20Other%20Compute%20Services.md)**
-- **[Section #9: Deployments & Insfrastructure](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%239%20-%20Deployments%20%26%20Infrastructure%20Management.md)**
+- **[Section #9: Deployments & Infrastructure](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%239%20-%20Deployments%20%26%20Infrastructure%20Management.md)**
 - **[Section #10: Global Infrastructure](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%2310%20-%20Global%20Infrastructure.md)**
 - **[Section #11: Cloud Integrations](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%2311%20-%20Cloud%20Integrations.md)**
 - **[Section #12: Cloud Monitoring](https://github.com/h-urena/aws-certified-cloud-practitioner/blob/main/Section%20%2312%20-%20Cloud%20Monitoring.md)**

--- a/Section #13 - VPCs & Networking.md
+++ b/Section #13 - VPCs & Networking.md
@@ -18,12 +18,12 @@
 </ul>
 
 <h3>Bastion Hosts</h3>
-<p>EC2 instance residing in a public subnet, that allows to SHH into the EC2 instances living in a private subnet</p>
+<p>EC2 instance residing in a public subnet, that allows SSH into the EC2 instances living in a private subnet</p>
 
 <h3>NACL - Network Access Control List</h3>
 <ul>
     <li>Firewall at <b>subnet</b> level</li>
-    <li>One NACL per subnet, new subnets are assigned to the defatul NACL</li>
+    <li>One NACL per subnet, new subnets are assigned to the default NACL</li>
     <li>One can set <b>allow/deny</b> rules. The default inbound/outbound NACLs rules have traffic allowed</li>
     <li>First rule number match will drive the decision (e.g. 100 over 200)</li>
     <li>Stateless</li>

--- a/Section #14 - Security & Compliance.md
+++ b/Section #14 - Security & Compliance.md
@@ -33,13 +33,13 @@
 <p>Provision, manage and deploy SSL/TLS certificates</p>
 
 <h3>Secrets Manager</h3>
-<p>Store and force rotation opf secrets in RDS</p>
+<p>Store and force rotation of secrets in RDS</p>
 
 <h3>AWS Artifact</h3>
 <p>Portal to access AWS compliance documentations and AWS agreements</p>
 
 <h3>GuardDuty</h3>
-<p>Provision, manage, and deploy SSL/TLS certificates</p>
+<p>Intelligent threat discovery service that uses ML to continuously monitor and protect your AWS account</p>
 
 <h3>Inspector</h3>
 <ul>

--- a/Section #15 - Machine Learning.md
+++ b/Section #15 - Machine Learning.md
@@ -14,7 +14,7 @@
 
 <h3>Lex and Connect</h3>
 <ul>
-    <li>Lex: Automated speech rekon</li>
+    <li>Lex: Automated speech recognition</li>
     <li>Connect: virtual contact center</li>
 </ul>
 

--- a/Section #16 - Account Management, Billing & Support.md
+++ b/Section #16 - Account Management, Billing & Support.md
@@ -95,7 +95,7 @@
 <p>Notifies when one is close to an established service quota</p>
 
 <h3>Trusted Advisor</h3>
-<p>High-level account assessments, gouped by 6 categories</p>
+<p>High-level account assessments, grouped by 6 categories</p>
 
 <h3>Support Plans Pricing</h3>
 <ul>

--- a/Section #19 - Architecting & Ecosystem.md
+++ b/Section #19 - Architecting & Ecosystem.md
@@ -157,7 +157,7 @@
 <h4><b>AWS re:Post</b></h4>
 <ul>
     <li>AWS-managed Q&A forum service (alike Stack Overflow)</li>
-    <li>Not intended for time-sensitive, propietary help</li>
+    <li>Not intended for time-sensitive, proprietary help</li>
 </ul>
 
 <h4><b>AWS Managed Services</b></h4>

--- a/Section #2 - IAM.md
+++ b/Section #2 - IAM.md
@@ -75,7 +75,7 @@ Statement :
 <h3>Permission Boundaries</h3>
 <ul>
     <li>Boundaries that can be set to a user or a role (not a group)</li>
-    <li>The take precedence over session permissions policies</li>
+    <li>They take precedence over session permissions policies</li>
 </ul>
 
 <h3>IAM Identity Center</h3>

--- a/Section #4 - EC2 Instance Storage.md
+++ b/Section #4 - EC2 Instance Storage.md
@@ -27,7 +27,7 @@
 
 <h3>EBS Encryption</h3>
 <p>It has minimal impact on latency</p>
-<p>One can encrypt a decrypted volume</p>
+<p>One can encrypt an unencrypted volume</p>
 
 <h3>EFS - Elastic File System</h3>
 <p>Managed NFS (Network File System), which can be mounted on up to 100 EC2s (Linux/Multi AZ)</p>

--- a/Section #5 - ELB & ASG.md
+++ b/Section #5 - ELB & ASG.md
@@ -14,8 +14,8 @@
 <p>Why use a Load Balancer:</p>
 <ul>
     <li>Spread load across multiple downstream instances</li>
-    <li>Expose a single point of access (DNS) to you application</li>
-    <li>Seamlessly handle failures of the downstreamed instances</li>
+    <li>Expose a single point of access (DNS) to your application</li>
+    <li>Seamlessly handle failures of the downstream instances</li>
     <li>Regular health checks on one's instances</li>
     <li>Provide SSL termination (HTTPS) for one's websites</li>
     <li>Enforce stickiness with cookies</li>

--- a/Section #6 - Amazon S3.md
+++ b/Section #6 - Amazon S3.md
@@ -75,4 +75,4 @@
 </ul>
 <br>
 
-<p>S3 is <b>propietary</b>, one will need <b>AWS Storage Gateway</b> for a hybrid approach</p>
+<p>S3 is <b>proprietary</b>, one will need <b>AWS Storage Gateway</b> for a hybrid approach</p>

--- a/Section #7 - Databases & Analytics.md
+++ b/Section #7 - Databases & Analytics.md
@@ -10,7 +10,7 @@
 <p>Storage backed up by EBS</p>
 <p>Note: Can't SSH into an RDS instance</p>
 
-<h3>Aurora (propietary)</h3>
+<h3>Aurora (proprietary)</h3>
 <ul>
     <li>Supports PostgreSQL and MySQL</li>
     <li>Serverless function</li>


### PR DESCRIPTION
## Summary

Pre-publication cleanup pass to fix typos, grammar mistakes, and a critical factual error found across 11 files.

## Changes

### 🚨 Critical Fix
- **Section #14 (Security & Compliance):** `GuardDuty` was showing the description for ACM (AWS Certificate Manager) — *"Provision, manage, and deploy SSL/TLS certificates"*. Replaced with the correct definition: an ML-powered intelligent threat discovery service.

### Spelling
| File | Fix |
|------|-----|
| Section #6 - Amazon S3 | `propietary` → `proprietary` |
| Section #7 - Databases & Analytics | `propietary` → `proprietary` |
| Section #14 - Security & Compliance | `opf` → `of` |
| Section #15 - Machine Learning | `rekon` → `recognition` |
| Section #16 - Account Management | `gouped` → `grouped` |
| Section #19 - Architecting & Ecosystem | `propietary` → `proprietary` |
| README | `Insfrastructure` → `Infrastructure` |

### Grammar
| File | Fix |
|------|-----|
| Section #2 - IAM | `The take precedence` → `They take precedence` |
| Section #4 - EC2 Instance Storage | `encrypt a decrypted volume` → `encrypt an unencrypted volume` |
| Section #5 - ELB & ASG | `to you application` → `to your application` |
| Section #5 - ELB & ASG | `downstreamed instances` → `downstream instances` |
| Section #13 - VPCs & Networking | `defatul NACL` → `default NACL` |
| Section #13 - VPCs & Networking | `allows to SHH into` → `allows SSH into` |